### PR TITLE
Route params

### DIFF
--- a/lib/apiculture/method_documentation.rb
+++ b/lib/apiculture/method_documentation.rb
@@ -11,7 +11,7 @@ class Apiculture::MethodDocumentation
     @definition = action_definition
     @mountpoint = mountpoint
   end
-  
+
   # Compose a Markdown definition of the action
   def to_markdown
     m = MDBuf.new
@@ -20,42 +20,42 @@ class Apiculture::MethodDocumentation
     m << route_parameters_table
     m << request_parameters_table
     m << possible_responses_table
-    
+
     m.to_s
   end
-  
+
   # Compose an HTML string by converting the result of +to_markdown+
   def to_html_fragment
     require 'rdiscount'
     RDiscount.new(to_markdown).to_html
   end
-  
+
   private
-  
+
   class StringBuf #:nodoc:
     def initialize; @blocks = []; end
     def <<(block); @blocks << block.to_s; self; end
     def to_s; @blocks.join; end
   end
-  
+
   class MDBuf < StringBuf  #:nodoc:
     def to_s; @blocks.join("\n\n"); end
   end
-  
-  def route_parameters_table
+
+  def _route_parameters_table
     return '' unless @definition.defines_route_params?
-    
+
     m = MDBuf.new
     b = StringBuf.new
     m << '### URL parameters'
-    
+
     html = Builder::XmlMarkup.new(:target => b)
     html.table(class: 'apiculture-table') do
       html.tr do
         html.th 'Name'
         html.th 'Description'
       end
-      
+
       @definition.route_parameters.each do | param |
         html.tr do
           html.td { html.tt(':%s' % param.name) }
@@ -65,7 +65,7 @@ class Apiculture::MethodDocumentation
     end
     m << b.to_s
   end
-  
+
   def body_example(for_response_definition)
     if for_response_definition.no_body?
       '(empty)'
@@ -73,14 +73,14 @@ class Apiculture::MethodDocumentation
       JSON.pretty_generate(for_response_definition.jsonable_object_example)
     end
   end
-  
+
   def possible_responses_table
     return '' unless @definition.defines_responses?
-    
+
     m = MDBuf.new
     b = StringBuf.new
     m << '### Possible responses'
-    
+
     html = Builder::XmlMarkup.new(:target => b)
     html.table(class: 'apiculture-table') do
       html.tr do
@@ -88,7 +88,7 @@ class Apiculture::MethodDocumentation
         html.th('What happened')
         html.th('Example response body')
       end
-      
+
       @definition.responses.each do | resp |
         html.tr do
           html.td { html.b(resp.http_status_code) }
@@ -97,15 +97,27 @@ class Apiculture::MethodDocumentation
         end
       end
     end
-    
+
     m << b.to_s
   end
-  
+
   def request_parameters_table
     return '' unless @definition.defines_request_params?
-    
     m = MDBuf.new
     m << '### Request parameters'
+    m << parameters_table(@definition.parameters).to_s
+  end
+
+  def route_parameters_table
+    return '' unless @definition.defines_route_params?
+    m = MDBuf.new
+    m << '### URL parameters'
+    m << parameters_table(@definition.route_parameters).to_s
+  end
+
+
+  private
+  def parameters_table(parameters)
     b = StringBuf.new
     html = Builder::XmlMarkup.new(:target => b)
     html.table(class: 'apiculture-table') do
@@ -115,8 +127,8 @@ class Apiculture::MethodDocumentation
         html.th 'Type after cast'
         html.th 'Description'
       end
-      
-      @definition.parameters.each do | param |
+
+      parameters.each do | param |
         html.tr do
           html.td { html.tt(param.name.to_s) }
           html.td(param.required ? 'Yes' : 'No')
@@ -125,6 +137,6 @@ class Apiculture::MethodDocumentation
         end
       end
     end
-    m << b
+    b
   end
 end

--- a/spec/apiculture/app_documentation_spec.rb
+++ b/spec/apiculture/app_documentation_spec.rb
@@ -27,6 +27,11 @@ describe "Apiculture.api_documentation" do
       route_param :id, 'Pancake ID to delete'
       api_method :delete, '/pancake/:id' do
       end
+
+      desc 'Pancake ingredients are in the URL'
+      route_param :topping_id, 'Pancake topping id', Fixnum, cast: :to_i
+      api_method :get, '/pancake/with/:topping_id' do |topping_id|
+      end
     end
   }
   

--- a/spec/apiculture/method_documentation_spec.rb
+++ b/spec/apiculture/method_documentation_spec.rb
@@ -63,6 +63,24 @@ describe Apiculture::MethodDocumentation do
     expect(generated_html).not_to include('<h3>Request parameters</h3>')
   end
   
+  it 'generates HTML from an ActionDefinition with a casted route param' do
+    definition = Apiculture::ActionDefinition.new
+    
+    definition.description = "This adds a topping to a pancake"
+    
+    definition.route_parameters << Apiculture::RouteParameter.new(:topping_id, 'ID of the pancake topping', Fixnum, cast: :to_i)
+    definition.http_verb = 'get'
+    definition.path = '/pancake/:topping_id'
+    
+    documenter = described_class.new(definition)
+    
+    generated_html = documenter.to_html_fragment
+    generated_markdown = documenter.to_markdown
+    expect(generated_html).to include('<h3>URL parameters</h3>')
+    expect(generated_html).to include('Type after cast')
+  end
+
+
   it 'generates Markdown from an ActionDefinition with a mountpoint' do
     definition = Apiculture::ActionDefinition.new
     

--- a/spec/apiculture_spec.rb
+++ b/spec/apiculture_spec.rb
@@ -192,7 +192,7 @@ describe "Apiculture" do
       expect(last_response.body).to eq('Total success')
     end
 
-    it 'ensures current behaviour for route params is not changed', run: true do
+    it 'ensures current behaviour for route params is not changed' do
       @app_class = Class.new(Sinatra::Base) do
         settings.show_exceptions = false
         settings.raise_errors = true
@@ -208,7 +208,7 @@ describe "Apiculture" do
       expect(last_response.body).to eq('Total success')
     end
 
-    it 'ensures current behaviour when no route params are present does not change', run: true do
+    it 'ensures current behaviour when no route params are present does not change' do
       @app_class = Class.new(Sinatra::Base) do
         settings.show_exceptions = false
         settings.raise_errors = true
@@ -224,7 +224,7 @@ describe "Apiculture" do
       expect(last_response.body).to eq('Total success')
     end
 
-    it 'applies a symbol typecast by calling a method on the route parameter value', run: true do
+    it 'applies a symbol typecast by calling a method on the route parameter value' do
       @app_class = Class.new(Sinatra::Base) do
         settings.show_exceptions = false
         settings.raise_errors = true
@@ -240,8 +240,25 @@ describe "Apiculture" do
       expect(last_response.body).to eq('Total success')
     end
 
+
+    it 'cast block arguments to the right type', run: true do
+      @app_class = Class.new(Sinatra::Base) do
+        settings.show_exceptions = false
+        settings.raise_errors = true
+        extend Apiculture
+      
+        route_param :number, "Number of the thing", Fixnum, :cast => :to_i
+        api_method :post, '/thing/:number' do |number|
+          raise "Not cast" unless number.class == Fixnum
+          'Total success'
+        end
+      end
+      post '/thing/123'
+      expect(last_response.body).to eq('Total success')
+    end
+
     
-    it 'merges route_params and regular params', run: true do
+    it 'merges route_params and regular params' do
       @app_class = Class.new(Sinatra::Base) do
         settings.show_exceptions = false
         settings.raise_errors = true


### PR DESCRIPTION
When validating params route params were not taken into account which
caused them to be deleted from the `params` hash.

This required us to write code like this

```ruby
api_method :get, '/transfers/:id/:security_hash' do |id, security_hash|
    params[:id] = id
    params[:security_hash] = security_hash
    action_result Actions::ShowTransfer
end
```