### PR TITLE
Add check for fixnum on ruby versions pre 2.4

### DIFF
--- a/spec/apiculture_spec.rb
+++ b/spec/apiculture_spec.rb
@@ -321,7 +321,7 @@ describe "Apiculture" do
       
         route_param :number, "Number of the thing", Integer, :cast => :to_i
         api_method :post, '/thing/:number' do |number|
-          raise "Not cast" unless number.class == Integer
+          raise "Not cast" unless number.class == Integer || Fixnum # Fixnums were collapsed into Integers in 2.4
           'Total success'
         end
       end

--- a/spec/apiculture_spec.rb
+++ b/spec/apiculture_spec.rb
@@ -321,11 +321,18 @@ describe "Apiculture" do
       
         route_param :number, "Number of the thing", Integer, :cast => :to_i
         api_method :post, '/thing/:number' do |number|
-          raise "Not cast" unless number.class == Integer || Fixnum # Fixnums were collapsed into Integers in 2.4
+          # Fixnums and Bignums were collapsed into Integers in 2.4
+          raise "Not cast" unless number.class == Integer || Fixnum || Bignum 
           'Total success'
         end
       end
       post '/thing/123'
+      expect(last_response.body).to eq('Total success')
+    
+      # Double checking that bignums are okay, too
+      bignum = 10**30
+      expect(bignum.class).to eq(Bignum)
+      post "/thing/#{bignum}"
       expect(last_response.body).to eq('Total success')
     end
 


### PR DESCRIPTION
Though we properly check for Integer in this test, in versions of ruby before 2.4 the same `.class` call returns `Fixnum` or `Bignum`.