### PR TITLE
Refactor AppDocumentation

### DIFF
--- a/lib/apiculture.rb
+++ b/lib/apiculture.rb
@@ -203,7 +203,7 @@ module Apiculture
   #   MyApi.api_documentation.to_html #=> "..."
   def api_documentation
     require_relative 'apiculture/app_documentation'
-    AppDocumentation.new(self, @apiculture_mounted_at.to_s, @apiculture_actions_and_docs || [])
+    AppDocumentation.new(self, @apiculture_mounted_at.to_s, apiculture_stack)
   end
   
   # Define an API method. Under the hood will call the related methods in Sinatra
@@ -277,6 +277,5 @@ module Apiculture
   
   def apiculture_stack
     @apiculture_actions_and_docs ||= []
-    @apiculture_actions_and_docs
   end
 end

--- a/lib/apiculture/action_definition.rb
+++ b/lib/apiculture/action_definition.rb
@@ -28,7 +28,7 @@ class Apiculture::ActionDefinition
     @parameters, @route_parameters, @responses = [], [], []
   end
 
-  def to_markdown_slice(mountpoint = nil)
+  def to_tagged_markdown(mountpoint)
     md = Apiculture::MethodDocumentation.new(self, mountpoint).to_markdown
     TaggedMarkdown.new(md, 'apiculture-method')
   end

--- a/lib/apiculture/action_definition.rb
+++ b/lib/apiculture/action_definition.rb
@@ -27,4 +27,9 @@ class Apiculture::ActionDefinition
   def initialize
     @parameters, @route_parameters, @responses = [], [], []
   end
+
+  def to_markdown_slice(mountpoint = nil)
+    md = Apiculture::MethodDocumentation.new(self, mountpoint).to_markdown
+    TaggedMarkdown.new(md, 'apiculture-method')
+  end
 end

--- a/lib/apiculture/app_documentation.rb
+++ b/lib/apiculture/app_documentation.rb
@@ -13,7 +13,7 @@ class Apiculture::AppDocumentation
   
   # Generates a Markdown string that contains the entire API documentation
   def to_markdown
-    (['## %s' % @app_title] + to_markdown_slices).join(JOINER)
+    (['## %s' % @app_title] + to_tagged_markdowns).join(JOINER)
   end
 
   # Generates a complete HTML document string that can be saved into a file
@@ -25,12 +25,14 @@ class Apiculture::AppDocumentation
   
   # Generates an HTML fragment string that can be included into another HTML document
   def to_html_fragment
-    to_markdown_slices.map(&:to_html).join(JOINER)
+    to_tagged_markdowns.map(&:to_html).join(JOINER)
   end
+
+  private
   
-  def to_markdown_slices
-    @chunks.map do |action_def_or_doc|
-      action_def_or_doc.to_markdown_slice(@mountpoint)
+    def to_tagged_markdowns
+      @chunks.map do |action_def_or_doc|
+        action_def_or_doc.to_tagged_markdown(@mountpoint)
+      end
     end
-  end
 end

--- a/lib/apiculture/app_documentation.rb
+++ b/lib/apiculture/app_documentation.rb
@@ -1,20 +1,9 @@
 require_relative 'method_documentation'
-require 'github/markup'
+require_relative 'tagged_markdown'
 
 class Apiculture::AppDocumentation
-  class TaggedMarkdown < Struct.new(:string, :section_class)
-    def to_markdown
-      string.to_markdown.to_s rescue string.to_s
-    end
-    
-    def to_html
-      '<section class="%s">%s</section>' % [Rack::Utils.escape_html(section_class), render_markdown(to_markdown)]
-    end
-    
-    def render_markdown(s)
-      GitHub::Markup.render('section.markdown', s.to_s)
-    end
-  end
+  JOINER = "\n\n"
+  TEMPLATE_PATH = '/app_documentation_tpl.mustache'
   
   def initialize(app, mountpoint, action_definitions_and_markdown_segments)
     @app_title = app.to_s
@@ -24,31 +13,24 @@ class Apiculture::AppDocumentation
   
   # Generates a Markdown string that contains the entire API documentation
   def to_markdown
-    (['## %s' % @app_title] + to_markdown_slices).join("\n\n")
+    (['## %s' % @app_title] + to_markdown_slices).join(JOINER)
+  end
+
+  # Generates a complete HTML document string that can be saved into a file
+  def to_html
+    require 'mustache'
+    template = File.read(__dir__ + TEMPLATE_PATH)
+    Mustache.render(template, html_fragment: to_html_fragment)
   end
   
   # Generates an HTML fragment string that can be included into another HTML document
   def to_html_fragment
-    to_markdown_slices.map do |tagged_markdown|
-      tagged_markdown.to_html
-    end.join("\n\n")
+    to_markdown_slices.map(&:to_html).join(JOINER)
   end
   
   def to_markdown_slices
-    markdown_slices = @chunks.map do | action_def_or_doc |
-      if action_def_or_doc.respond_to?(:http_verb) # ActionDefinition
-        s = Apiculture::MethodDocumentation.new(action_def_or_doc, @mountpoint).to_markdown
-        TaggedMarkdown.new(s, 'apiculture-method')
-      elsif action_def_or_doc.respond_to?(:to_markdown)
-        TaggedMarkdown.new(action_def_or_doc, 'apiculture-verbatim')
-      end
+    @chunks.map do |action_def_or_doc|
+      action_def_or_doc.to_markdown_slice(@mountpoint)
     end
-  end
-  
-  # Generates a complete HTML document string that can be saved into a file
-  def to_html
-    require 'mustache'
-    template = File.read(__dir__ + '/app_documentation_tpl.mustache')
-    Mustache.render(template, :html_fragment => to_html_fragment)
   end
 end

--- a/lib/apiculture/markdown_segment.rb
+++ b/lib/apiculture/markdown_segment.rb
@@ -4,7 +4,7 @@ class Apiculture::MarkdownSegment < Struct.new(:string)
     string.to_s
   end
 
-  def to_markdown_slice(_mountpoint)
+  def to_tagged_markdown(_mountpoint)
     TaggedMarkdown.new(self, 'apiculture-verbatim')
   end
 end

--- a/lib/apiculture/markdown_segment.rb
+++ b/lib/apiculture/markdown_segment.rb
@@ -3,4 +3,8 @@ class Apiculture::MarkdownSegment < Struct.new(:string)
   def to_markdown
     string.to_s
   end
+
+  def to_markdown_slice(_mountpoint)
+    TaggedMarkdown.new(self, 'apiculture-verbatim')
+  end
 end

--- a/lib/apiculture/tagged_markdown.rb
+++ b/lib/apiculture/tagged_markdown.rb
@@ -1,0 +1,15 @@
+require 'github/markup'
+
+class TaggedMarkdown < Struct.new(:string, :section_class)
+  def to_markdown
+    string.to_markdown.to_s rescue string.to_s
+  end
+  
+  def to_html
+    '<section class="%s">%s</section>' % [Rack::Utils.escape_html(section_class), render_markdown(to_markdown)]
+  end
+  
+  def render_markdown(s)
+    GitHub::Markup.render('section.markdown', s.to_s)
+  end
+end

--- a/lib/apiculture/timestamp_promise.rb
+++ b/lib/apiculture/timestamp_promise.rb
@@ -4,7 +4,7 @@ class Apiculture::TimestampPromise
     "Documentation built on #{ts}"
   end
 
-  def self.to_markdown_slice(_mountpoint)
+  def self.to_tagged_markdown(_mountpoint)
     TaggedMarkdown.new(self, 'apiculture-verbatim')
   end
 end

--- a/lib/apiculture/timestamp_promise.rb
+++ b/lib/apiculture/timestamp_promise.rb
@@ -3,4 +3,8 @@ class Apiculture::TimestampPromise
     ts = Time.now.utc.strftime "%Y-%m-%d %H:%M"
     "Documentation built on #{ts}"
   end
+
+  def self.to_markdown_slice(_mountpoint)
+    TaggedMarkdown.new(self, 'apiculture-verbatim')
+  end
 end


### PR DESCRIPTION
The first step to making #17 a reality.

Changes: 
* I have removed all `.respond_to?` checks from `AppDocumentation` class by adding the method `to_tagged_markdown` to all classes that used to build up documentation. 
* Removed so redundant code from `lib/apiculture.rb`
* Defined some constants in `AppDocumentation` instead of "magic" text
* Extracted `TaggedMarkdown` into a separate file as its now used by multiple classes

