### PR TITLE
Apply Markdown in parameter/response descriptions

### DIFF
--- a/lib/apiculture/method_documentation.rb
+++ b/lib/apiculture/method_documentation.rb
@@ -1,4 +1,6 @@
 require 'builder'
+require 'rdiscount'
+
 # Generates Markdown/HTML documentation about a single API action.
 #
 # Formats route parameters and request/QS parameters as a neat HTML
@@ -26,11 +28,14 @@ class Apiculture::MethodDocumentation
 
   # Compose an HTML string by converting the result of +to_markdown+
   def to_html_fragment
-    require 'rdiscount'
-    RDiscount.new(to_markdown).to_html
+    markdown_string_to_html(to_markdown)
   end
 
   private
+
+  def markdown_string_to_html(str)
+    RDiscount.new(str.to_s).to_html
+  end
 
   class StringBuf #:nodoc:
     def initialize; @blocks = []; end
@@ -59,7 +64,7 @@ class Apiculture::MethodDocumentation
       @definition.route_parameters.each do | param |
         html.tr do
           html.td { html.tt(':%s' % param.name) }
-          html.td(param.description)
+          html.td { html << markdown_string_to_html(param.description) }
         end
       end
     end
@@ -98,7 +103,7 @@ class Apiculture::MethodDocumentation
       @definition.responses.each do | resp |
         html.tr do
           html.td { html.b(resp.http_status_code) }
-          html.td resp.description
+          html.td { html << markdown_string_to_html(resp.description) }
           html.td { html.pre { html.code(body_example(resp)) }}
         end
       end
@@ -139,7 +144,7 @@ class Apiculture::MethodDocumentation
           html.td { html.tt(param.name.to_s) }
           html.td(param.required ? 'Yes' : 'No')
           html.td(param.matchable.inspect)
-          html.td(param.description.to_s)
+          html.td { html << markdown_string_to_html(param.description) }
         end
       end
     end

--- a/spec/apiculture/app_documentation_spec.rb
+++ b/spec/apiculture/app_documentation_spec.rb
@@ -10,9 +10,16 @@ describe "Apiculture.api_documentation" do
       documentation_build_time!
       
       desc 'Order a pancake'
-      required_param :diameter, "Diameter of the pancake", Integer
+      required_param :diameter, "Diameter of the pancake. The pancake will be **bold**", Integer
       param :topping, 'Type of topping', String
-      responds_with 200, 'When the pancake is created succesfully', {id: 'abdef..c21'}
+      pancake_response_info = <<~EOS
+        When the pancake has been baked succesfully
+        The pancake will have the following properties:
+        
+        * It is going to be round
+        * It is going to be delicious
+        EOS
+      responds_with 200, pancake_response_info, {id: 'abdef..c21'}
       api_method :post, '/pancakes' do
       end
       
@@ -58,7 +65,7 @@ describe "Apiculture.api_documentation" do
    
     expect(generated_html).to include('<body')
     expect(generated_html).to include('Pancake ID to check status on')
-    expect(generated_html).to include('When the pancake is created succesfully')
+    expect(generated_html).to include('When the pancake has been baked succesfully')
     expect(generated_html).to include('"id": "abdef..c21"')
   end
   

--- a/spec/apiculture/method_documentation_spec.rb
+++ b/spec/apiculture/method_documentation_spec.rb
@@ -7,7 +7,7 @@ describe Apiculture::MethodDocumentation do
     
     definition.description = "This action bakes pancakes"
     definition.parameters << Apiculture::Parameter.new(:name, 'Pancake name', true, String, :to_s)
-    definition.parameters << Apiculture::Parameter.new(:thickness, 'Pancake thickness', false, Float, :to_f)
+    definition.parameters << Apiculture::Parameter.new(:thickness, 'Pancake **thick**ness', false, Float, :to_f)
     definition.parameters << Apiculture::Parameter.new(:diameter, 'Pancake diameter', false, Integer, :to_i)
     
     definition.route_parameters << Apiculture::RouteParameter.new(:pan_id, 'ID of the pancake frying pan')
@@ -28,9 +28,9 @@ describe Apiculture::MethodDocumentation do
     expect(generated_html).to include('<h3>URL parameters</h3>')
     expect(generated_html).to include('ID of the pancake frying pan')
     expect(generated_html).to include('<h3>Request parameters</h3>')
-    expect(generated_html).to include('<td>Pancake name</td>')
-    expect(generated_html).to include('<td>Pancake has been baked</td>')
-    expect(generated_html).to include('<td>Frying pan too cold</td>')
+    expect(generated_html).to include('<p>Pancake name</p>')
+    expect(generated_html).to include('<p>Pancake has been baked</p>')
+    expect(generated_html).to include('<p>Frying pan too cold</p>')
   end
   
   it 'generates HTML from an ActionDefinition without route params' do
@@ -38,7 +38,7 @@ describe Apiculture::MethodDocumentation do
     
     definition.description = "This action bakes pancakes"
     definition.parameters << Apiculture::Parameter.new(:name, 'Pancake name', true, String, :to_s)
-    definition.parameters << Apiculture::Parameter.new(:thickness, 'Pancake thickness', false, Float, :to_f)
+    definition.parameters << Apiculture::Parameter.new(:thickness, 'Pancake **thick**ness', false, Float, :to_f)
     definition.parameters << Apiculture::Parameter.new(:diameter, 'Pancake diameter', false, Integer, :to_i)
     
     definition.http_verb = 'get'


### PR DESCRIPTION
It is useful to be able to include lists and especially code blocks in these descriptions.