### PR TITLE
Simplifies Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,10 @@ gemfile:
   - gemfiles/Gemfile.rack-1.x
   - gemfiles/Gemfile.rack-2.x
 rvm:
-  - '2.3.8'
-  - '2.4.6'
-  - '2.5.5'
-  - '2.6.3'
-  - '2.7.0-preview1'
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
 sudo: false
 cache: bundler
-matrix:
-  allow_failures:
-    - rvm: 2.7.0-preview1


### PR DESCRIPTION
To make sure we test against current rubies, we don't want any of the current Rubies to allow to fail.

Also, specifing Major.Minor over Major.Minor.~Patch~Teeny allows for easier maintenance

Edit: Updated text to use proper wording.