### PR TITLE
Bump github-markup dependency

### DIFF
--- a/apiculture.gemspec
+++ b/apiculture.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'mustermann', '~> 1'
   s.add_runtime_dependency 'builder', '~> 3'
   s.add_runtime_dependency 'rdiscount', '~> 2'
-  s.add_runtime_dependency 'github-markup', '~> 1'
+  s.add_runtime_dependency 'github-markup', '~> 3'
   s.add_runtime_dependency 'mustache', '~> 1'
 
   s.add_development_dependency 'rack-test'

--- a/lib/apiculture/version.rb
+++ b/lib/apiculture/version.rb
@@ -1,3 +1,3 @@
 module Apiculture
-  VERSION = '0.1.5'.freeze
+  VERSION = '0.1.6'
 end


### PR DESCRIPTION
Looks like there were quite a few version updates, and we should keep pace