### PR TITLE
chore: add support for nested fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 0.2.0
 * Add ruby 3 support
 * Bump `mustermann` dependency to '~> 3'
+
+
+## 0.2.1
+* Add support for nested fields

--- a/lib/apiculture/openapi_documentation.rb
+++ b/lib/apiculture/openapi_documentation.rb
@@ -8,9 +8,9 @@ module OpenApiDocumentation
       @paths = chunks.select { |chunk| chunk.respond_to?(:http_verb) }
       @data = {
         openapi: '3.0.0',
-        info: { 
-          title: @app.to_s, 
-          version: '0.0.1', 
+        info: {
+          title: @app.to_s,
+          version: '0.0.1',
           description: @app.to_s + " " + chunks.select { |chunk| chunk.respond_to?(:to_markdown) }.map(&:to_markdown).join("\n")
         },
         tags: []
@@ -27,7 +27,7 @@ module OpenApiDocumentation
     end
 
     def spec
-      @data      
+      @data
     end
 
     private
@@ -137,7 +137,7 @@ module OpenApiDocumentation
 
     def build_request_body
       return nil if VERBS_WITHOUT_BODY.include?(@path.http_verb)
-      
+
       body_params = Hash[ @path.parameters.collect do |parameter|
         [parameter.name, {
           type: Util.map_type(parameter.matchable),
@@ -171,7 +171,7 @@ module OpenApiDocumentation
         unless response.jsonable_object_example.nil? || response.jsonable_object_example.empty?
           _response[:content] = {
             'application/json': {
-                schema: 
+                schema:
                   { type: 'object',
                   properties: Util.response_to_schema(response.jsonable_object_example) }
             }
@@ -197,16 +197,40 @@ module OpenApiDocumentation
       TrueClass => true
     }.freeze
 
-    def self.response_to_schema(response)
-      schema = {}
-      return nil if response.nil? || response.empty? || response.class == String
-      response.each do |key, value|
-        schema[key] = {
-          type: 'string',
-          example: value.to_s
-        }
+    def self.value_schema(value)
+      case value
+      when String
+        { type: 'string', example: value }
+      when Integer
+        { type: 'integer', example: value }
+      when Float
+        { type: 'float', example: value }
+      when Array
+        if value.empty?
+          { type: 'array', items: {} }
+        else
+          { type: 'array', items: value.map { |elem| value_schema(elem) } }
+        end
+      when Hash
+        value.each_with_object({}) do |(key, val), schema_hash|
+          schema_hash[key] = value_schema(val)
+        end
+      else
+        { type: value.class.name.downcase, example: value.to_s }
       end
-      schema
+    end
+
+    def self.response_to_schema(response)
+      return nil if response.nil?
+
+      case response
+      when Hash
+        response.empty? ? nil : response.each_with_object({}) do |(key, val), schema_hash|
+          schema_hash[key] = value_schema(val)
+        end
+      else
+        value_schema(response)
+      end
     end
 
     def self.map_type(type)

--- a/lib/apiculture/openapi_documentation.rb
+++ b/lib/apiculture/openapi_documentation.rb
@@ -197,39 +197,27 @@ module OpenApiDocumentation
       TrueClass => true
     }.freeze
 
-    def self.value_schema(value)
-      case value
+    def self.response_to_schema(response)
+      case response
+      when NilClass
       when String
-        { type: 'string', example: value }
+        { type: 'string', example: response }
       when Integer
-        { type: 'integer', example: value }
+        { type: 'integer', example: response }
       when Float
-        { type: 'float', example: value }
+        { type: 'float', example: response }
       when Array
-        if value.empty?
+        if response.empty?
           { type: 'array', items: {} }
         else
-          { type: 'array', items: value.map { |elem| value_schema(elem) } }
+          { type: 'array', items: response.map { |elem| response_to_schema(elem) } }
         end
       when Hash
-        value.each_with_object({}) do |(key, val), schema_hash|
-          schema_hash[key] = value_schema(val)
+        response.each_with_object({}) do |(key, val), schema_hash|
+          schema_hash[key] = response_to_schema(val)
         end
       else
-        { type: value.class.name.downcase, example: value.to_s }
-      end
-    end
-
-    def self.response_to_schema(response)
-      return nil if response.nil?
-
-      case response
-      when Hash
-        response.empty? ? nil : response.each_with_object({}) do |(key, val), schema_hash|
-          schema_hash[key] = value_schema(val)
-        end
-      else
-        value_schema(response)
+        { type: response.class.name.downcase, example: response.to_s }
       end
     end
 

--- a/lib/apiculture/version.rb
+++ b/lib/apiculture/version.rb
@@ -1,3 +1,3 @@
 module Apiculture
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.2.1'.freeze
 end

--- a/spec/apiculture/openapi_documentation_spec.rb
+++ b/spec/apiculture/openapi_documentation_spec.rb
@@ -17,7 +17,7 @@ describe 'Apiculture.api_documentation' do
         * It is going to be round
         * It is going to be delicious
       EOS
-      responds_with 200, pancake_response_info, { id: 'abdef..c21' }
+      responds_with 200, pancake_response_info, { id: 'abdef..c21', one: { two: [{ three: 'four' }], five: 6, seven: [8] } }
       api_method :post, '/pancakes' do
       end
 
@@ -112,6 +112,34 @@ describe 'Apiculture.api_documentation' do
             end
           end
         end
+
+        describe 'response body schema' do
+          let(:schema) { post_pancakes.dig(:responses, '200', :content, :'application/json', :schema) }
+
+          it 'will have the correct response body schema' do
+            expect(schema).to eq(
+              {
+                type: 'object',
+                properties: {
+                  id: {
+                    type: 'string', example: 'abdef..c21'
+                  },
+                  one: {
+                    two: {
+                      type: 'array', items: [{ three: { type: 'string', example: 'four' } }]
+                    },
+                    five: {
+                      type: 'integer', example: 6
+                    },
+                    seven: {
+                      type: 'array', items: [{ type: 'integer', example: 8 }]
+                    }
+                  }
+                }
+              }
+            )
+          end
+        end
       end
 
       context 'GET /pancake/:id' do
@@ -180,7 +208,7 @@ describe 'Apiculture.api_documentation' do
 
             describe 'schema' do
               let(:schema) { response_200.dig(:content, :'application/json', :schema) }
-              
+
               it 'will have object type' do
                 expect(schema).to include(type: 'object')
               end

--- a/spec/apiculture/openapi_documentation_spec.rb
+++ b/spec/apiculture/openapi_documentation_spec.rb
@@ -17,7 +17,10 @@ describe 'Apiculture.api_documentation' do
         * It is going to be round
         * It is going to be delicious
       EOS
-      responds_with 200, pancake_response_info, { id: 'abdef..c21', one: { two: [{ three: 'four' }], five: 6, seven: [8] } }
+      responds_with 200, pancake_response_info, {
+        id: 'abdef..c21',
+        one: { two: [{ three: 'four' }], five: 6, seven: [8], nine: nil }
+      }
       api_method :post, '/pancakes' do
       end
 
@@ -133,7 +136,8 @@ describe 'Apiculture.api_documentation' do
                     },
                     seven: {
                       type: 'array', items: [{ type: 'integer', example: 8 }]
-                    }
+                    },
+                    nine: nil
                   }
                 }
               }


### PR DESCRIPTION
This PR adds support for nested fields (objects, arrays)

### Example response:
```ruby
{ 
  id: 'abdef..c21', 
  one: { two: [{ three: 'four' }], five: 6, seven: [8] } 
}
```

### Before:

```ruby
{
  properties: {
    id: {
      example: "abdef..c21", type: "string" 
    }, 
    one: {
      example: "{:two=>[{:three=>\"four\"}], :five=>6, :seven=>[8]}", 
      type: "string"
    }
  }
}
```

### After:

```ruby
{
  type: 'object',
  properties: {
    id: {
      type: 'string', example: 'abdef..c21'
    },
    one: {
      two: {
        type: 'array', items: [{ three: { type: 'string', example: 'four' } }]
      },
      five: {
        type: 'integer', example: 6
      },
      seven: {
        type: 'array', items: [{ type: 'integer', example: 8 }]
      }
    }
  }
}
```
